### PR TITLE
Use dynamic import for QR code creator

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,16 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { QrCode, BarChart, Settings } from "lucide-react"
-import QrCodeCreator from "@/components/qr-code-creator"
+import dynamic from "next/dynamic"
+
+const QrCodeCreator = dynamic(() => import("@/components/qr-code-creator"), {
+  ssr: false,
+  loading: () => (
+    <div className="min-h-[600px] flex items-center justify-center">
+      Loading QR UI...
+    </div>
+  ),
+})
 
 import Header from "@/components/header";
 import Footer from "@/components/footer";


### PR DESCRIPTION
## Summary
- lazily load the `QrCodeCreator` with `next/dynamic`
- show placeholder while the QR UI is loading

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68426189bdec832aa24d050d371f49a1