### PR TITLE
Add custom domain support

### DIFF
--- a/src/app/api/custom-domain/route.ts
+++ b/src/app/api/custom-domain/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { StackServerApp } from "@stackframe/stack";
+import { randomBytes } from "crypto";
+
+const stack = new StackServerApp({
+  tokenStore: "nextjs-cookie",
+  urls: { signIn: "/login" },
+});
+
+export async function POST(request: NextRequest) {
+  const { domain } = await request.json();
+  if (!domain) {
+    return NextResponse.json({ error: "Domain is required" }, { status: 400 });
+  }
+
+  const user = await stack.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = randomBytes(16).toString("hex");
+
+  await user.update({
+    serverMetadata: {
+      ...(user.serverMetadata || {}),
+      customDomain: domain,
+      customDomainToken: token,
+      customDomainVerified: false,
+    },
+  });
+
+  return NextResponse.json({ token });
+}

--- a/src/app/api/custom-domain/verify/route.ts
+++ b/src/app/api/custom-domain/verify/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { StackServerApp } from "@stackframe/stack";
+import { promises as dns } from "dns";
+
+const stack = new StackServerApp({
+  tokenStore: "nextjs-cookie",
+  urls: { signIn: "/login" },
+});
+
+export async function POST(request: NextRequest) {
+  const { domain } = await request.json();
+  if (!domain) {
+    return NextResponse.json({ error: "Domain is required" }, { status: 400 });
+  }
+
+  const user = await stack.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = user.serverMetadata?.customDomainToken;
+  if (!token) {
+    return NextResponse.json({ error: "No domain pending verification" }, { status: 400 });
+  }
+
+  try {
+    const records = await dns.resolveTxt(`_qrco.${domain}`);
+    const flattened = records.map((r) => r.join(""));
+    const verified = flattened.includes(token);
+    if (!verified) {
+      return NextResponse.json({ error: "Verification record not found" }, { status: 400 });
+    }
+
+    await user.update({
+      serverMetadata: {
+        ...(user.serverMetadata || {}),
+        customDomainVerified: true,
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("DNS lookup error:", err);
+    return NextResponse.json({ error: "DNS lookup failed" }, { status: 400 });
+  }
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,19 @@
+import { StackServerApp } from "@stackframe/stack";
+import CustomDomainForm from "@/components/custom-domain-form";
+
+export default async function SettingsPage() {
+  const stack = new StackServerApp({
+    tokenStore: "nextjs-cookie",
+    urls: { signIn: "/login" },
+  });
+  const user = await stack.getUser();
+  const meta = user?.serverMetadata || {};
+  return (
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-3xl font-bold tracking-tight">Settings</h2>
+      </div>
+      <CustomDomainForm initialDomain={meta.customDomain ?? ""} verified={!!meta.customDomainVerified} />
+    </div>
+  );
+}

--- a/src/components/custom-domain-form.tsx
+++ b/src/components/custom-domain-form.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface Props {
+  initialDomain: string;
+  verified: boolean;
+}
+
+export default function CustomDomainForm({ initialDomain, verified }: Props) {
+  const [domain, setDomain] = useState(initialDomain);
+  const [token, setToken] = useState<string | null>(null);
+  const [status, setStatus] = useState(verified ? "verified" : "idle");
+  const [loading, setLoading] = useState(false);
+
+  const register = async () => {
+    setLoading(true);
+    const res = await fetch("/api/custom-domain", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain }),
+    });
+    const data = await res.json();
+    setLoading(false);
+    if (res.ok) {
+      setToken(data.token);
+      setStatus("pending");
+    } else {
+      alert(data.error || "Failed to register domain");
+    }
+  };
+
+  const verify = async () => {
+    setLoading(true);
+    const res = await fetch("/api/custom-domain/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain }),
+    });
+    const data = await res.json();
+    setLoading(false);
+    if (res.ok) {
+      setStatus("verified");
+    } else {
+      alert(data.error || "Verification failed");
+    }
+  };
+
+  return (
+    <div className="space-y-4 max-w-md">
+      <div className="grid gap-2">
+        <Label htmlFor="domain">Custom Domain</Label>
+        <Input id="domain" value={domain} onChange={(e) => setDomain(e.target.value)} placeholder="example.com" />
+      </div>
+      {status === "idle" && (
+        <Button onClick={register} disabled={loading || !domain}>Save Domain</Button>
+      )}
+      {status === "pending" && token && (
+        <div className="space-y-2">
+          <p>Add a TXT record for <code>_qrco.{domain}</code> with the value:</p>
+          <pre className="rounded bg-muted p-2 text-sm">{token}</pre>
+          <Button onClick={verify} disabled={loading}>Verify Domain</Button>
+        </div>
+      )}
+      {status === "verified" && (
+        <p className="text-green-600">Domain verified: {domain}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow users to register and verify a custom domain for short links
- show custom domain form in dashboard settings
- API routes for registration and DNS verification

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b414aa648832aa9898df655f8dab8