### PR TITLE
Add custom domain API and dashboard support

### DIFF
--- a/src/app/[code]/route.ts
+++ b/src/app/[code]/route.ts
@@ -1,9 +1,14 @@
 import { buildSignedUrl } from "@/lib/storage"; // or wherever you generate file URLs
 import { type NextRequest, NextResponse } from "next/server"
 import { getQRByCode, logScan } from "@/lib/qr-service"
+import { getTenantByDomain } from "@/lib/domain-service"
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ code: string }> }) {
   const { code } = await params
+
+  const host = request.headers.get('host') || ''
+  const tenant = await getTenantByDomain(host)
+  console.log('Incoming host:', host, 'tenant:', tenant)
 
   // Get the QR code from the database
   const qr = await getQRByCode(code)

--- a/src/app/api/add-domain/route.ts
+++ b/src/app/api/add-domain/route.ts
@@ -1,0 +1,47 @@
+export const runtime = 'nodejs'
+import { NextResponse } from 'next/server'
+import { StackServerApp } from '@stackframe/stack'
+import { saveDomain } from '@/lib/domain-service'
+import { isApexDomain } from '@/lib/utils'
+
+const stack = new StackServerApp({
+  tokenStore: 'nextjs-cookie',
+  urls: { signIn: '/login' },
+})
+
+export async function POST(request: Request) {
+  const { domain } = await request.json()
+  if (!domain) {
+    return NextResponse.json({ error: 'Domain is required' }, { status: 400 })
+  }
+
+  const user = await stack.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const token = process.env.VERCEL_API_TOKEN
+  const projectId = process.env.VERCEL_PROJECT_ID
+  if (!token || !projectId) {
+    return NextResponse.json({ error: 'Missing Vercel credentials' }, { status: 500 })
+  }
+
+  const res = await fetch(`https://api.vercel.com/v10/projects/${projectId}/domains`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: domain }),
+  })
+
+  const data = await res.json()
+  if (!res.ok) {
+    return NextResponse.json(data, { status: res.status })
+  }
+
+  const status = data?.verified ? 'active' : 'pending'
+  await saveDomain(user.id, domain, status)
+
+  return NextResponse.json({ domain, type: isApexDomain(domain) ? 'apex' : 'subdomain', status })
+}

--- a/src/app/api/domain-status/route.ts
+++ b/src/app/api/domain-status/route.ts
@@ -1,0 +1,25 @@
+export const runtime = 'nodejs'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const domain = request.nextUrl.searchParams.get('domain')
+  if (!domain) {
+    return NextResponse.json({ error: 'Domain required' }, { status: 400 })
+  }
+
+  const token = process.env.VERCEL_API_TOKEN
+  const projectId = process.env.VERCEL_PROJECT_ID
+  if (!token || !projectId) {
+    return NextResponse.json({ error: 'Missing Vercel credentials' }, { status: 500 })
+  }
+
+  const res = await fetch(`https://api.vercel.com/v6/domains/${domain}?projectId=${projectId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  const data = await res.json()
+  if (!res.ok) {
+    return NextResponse.json(data, { status: res.status })
+  }
+
+  return NextResponse.json({ configured: data.configured, verified: data.verified, misconfigured: data.misconfigured })
+}

--- a/src/app/dashboard/domains/client.tsx
+++ b/src/app/dashboard/domains/client.tsx
@@ -1,0 +1,87 @@
+"use client"
+import { useState, useEffect } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+import { isApexDomain } from '@/lib/utils'
+
+interface DomainEntry {
+  id: string
+  user_id: string
+  name: string
+  status: string
+}
+
+interface Props {
+  initialDomains: DomainEntry[]
+}
+
+export function DomainClient({ initialDomains }: Props) {
+  const [domains, setDomains] = useState<DomainEntry[]>(initialDomains)
+  const [value, setValue] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const addDomain = async () => {
+    if (!value) return
+    setLoading(true)
+    const res = await fetch('/api/add-domain', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain: value })
+    })
+    const data = await res.json()
+    if (res.ok) {
+      setDomains([{ id: value, user_id: '', name: value, status: data.status }, ...domains])
+      toast.success('Domain added')
+      setValue('')
+    } else {
+      toast.error(data.error || 'Failed to add domain')
+    }
+    setLoading(false)
+  }
+
+  const fetchStatus = async (domain: string) => {
+    const res = await fetch(`/api/domain-status?domain=${domain}`)
+    if (!res.ok) return null
+    return await res.json()
+  }
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      domains.forEach(async d => {
+        const s = await fetchStatus(d.name)
+        if (s && s.verified && d.status !== 'active') {
+          setDomains(cur => cur.map(x => x.name === d.name ? { ...x, status: 'active' } : x))
+        }
+      })
+    }, 10000)
+    return () => clearInterval(interval)
+  }, [domains])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2 max-w-md">
+        <Input value={value} onChange={e => setValue(e.target.value)} placeholder="example.com" />
+        <Button onClick={addDomain} disabled={loading}>{loading ? 'Adding...' : 'Add'}</Button>
+      </div>
+      <ul className="space-y-2">
+        {domains.map(d => (
+          <li key={d.name} className="border rounded p-2">
+            <div className="font-medium">{d.name}</div>
+            <DomainInstructions domain={d.name} />
+            <div className="text-sm text-muted-foreground">Status: {d.status}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function DomainInstructions({ domain }: { domain: string }) {
+  const apex = isApexDomain(domain)
+  return apex ? (
+    <p className="text-sm">Create two A records for <b>{domain}</b>: 76.76.21.21</p>
+  ) : (
+    <p className="text-sm">Create a CNAME record pointing <b>{domain}</b> → tqrco.de</p>
+  )
+}

--- a/src/app/dashboard/domains/page.tsx
+++ b/src/app/dashboard/domains/page.tsx
@@ -1,0 +1,12 @@
+import { getDomains } from '@/lib/domain-service'
+import { DomainClient } from './client'
+
+export default async function DomainsPage() {
+  const domains = await getDomains()
+  return (
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+      <h2 className="text-3xl font-bold tracking-tight">Custom Domains</h2>
+      <DomainClient initialDomains={domains} />
+    </div>
+  )
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -16,7 +16,8 @@ import {
   IconUsers,
   IconQrcode,
   IconCreditCard,
-  IconBrush
+  IconBrush,
+  IconGlobe
 } from "@tabler/icons-react"
 
 import { NavDocuments } from "@/components/nav-documents"
@@ -67,6 +68,11 @@ export const data = {
       title: "Billing",
       url: "/dashboard/billing",
       icon: IconCreditCard,
+    },
+    {
+      title: "Domains",
+      url: "/dashboard/domains",
+      icon: IconGlobe,
     },
   ],
   navClouds: [

--- a/src/lib/domain-service.ts
+++ b/src/lib/domain-service.ts
@@ -1,0 +1,42 @@
+import { query } from './db'
+import { StackServerApp } from '@stackframe/stack'
+
+const stackServerApp = new StackServerApp({
+  tokenStore: 'nextjs-cookie',
+  urls: { signIn: '/login' },
+})
+
+export interface DomainEntry {
+  id: string
+  user_id: string
+  name: string
+  status: string
+}
+
+export async function saveDomain(userId: string, name: string, status: string) {
+  try {
+    await query<DomainEntry[]>(
+      'INSERT INTO "Domain" (user_id, name, status) VALUES ($1, $2, $3) RETURNING *',
+      [userId, name, status],
+    )
+  } catch (error) {
+    console.error('Failed to save domain', error)
+  }
+}
+
+export async function getDomains(): Promise<DomainEntry[]> {
+  const user = await stackServerApp.getUser()
+  if (!user) return []
+  return await query<DomainEntry[]>(
+    'SELECT * FROM "Domain" WHERE user_id = $1 ORDER BY created_at DESC',
+    [user.id],
+  )
+}
+
+export async function getTenantByDomain(domain: string): Promise<string | null> {
+  const result = await query<{ user_id: string }[]>(
+    'SELECT user_id FROM "Domain" WHERE name = $1 LIMIT 1',
+    [domain],
+  )
+  return result.length ? result[0].user_id : null
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -370,3 +370,10 @@ export function contrastRatio(hex1: string, hex2: string) {
   return (bright + 0.05) / (dark + 0.05);
 }
 
+export function isApexDomain(domain: string): boolean {
+  return domain.split('.').length <= 2;
+}
+
+export function isSubdomain(domain: string): boolean {
+  return !isApexDomain(domain);
+}


### PR DESCRIPTION
## Summary
- add domain helpers and API to register custom domains on Vercel
- expose endpoint to poll domain status
- include utility helpers to check apex vs subdomain
- detect tenant via host header
- provide dashboard UI for managing domains
- link domain management page in sidebar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b4acffcc8832aa0513e6139ec09ff